### PR TITLE
feat: optimize 5 skill scores (0% → 99% avg) + add Tessl review workflow

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,22 @@
+# Tessl Skill Review — runs on PRs that change any SKILL.md; posts scores as one PR comment.
+# Docs: https://github.com/tesslio/skill-review
+name: Tessl Skill Review
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/SKILL.md"
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@main
+      # Optional quality gate (off by default):
+      # with:
+      #   fail-threshold: 70

--- a/skills/docker/SKILL.md
+++ b/skills/docker/SKILL.md
@@ -1,42 +1,107 @@
 ---
 name: docker
-description: Docker makes "works on my machine" a deployment strategy. Package your app with its dependencies, run it anywhere. But Docker's simplicity hides real complexity. A naive Dockerfile can be 10x larger and slower than it needs to be.  This skill covers Dockerfile optimization, multi-stage builds, Docker Compose for development, security hardening, and production patterns. Key insight: your Dockerfile is code. Review it, optimize it, version it.  2025 lesson: Containers aren't VMs. The patterns that work for VMs (install everything, big base images) are anti-patterns for containers. Think small, think immutable, think layers. Use when "docker, dockerfile, container, docker compose, docker build, containerize, docker image, multi-stage build, docker network, docker volume, docker, containers, devops, deployment, infrastructure, security, optimization" mentioned. 
+description: "Analyzes and generates production-ready Dockerfiles, Docker Compose configurations, and container security hardening. Optimizes image size via multi-stage builds, layer caching, and minimal base images. Reviews Dockerfiles for security issues (root user, secrets in layers, missing .dockerignore) and applies fixes. Use when docker, dockerfile, container, docker-compose, docker build, containerize, multi-stage build, image optimization, container security, or devops is mentioned."
 ---
 
 # Docker
 
-## Identity
+## Principles
 
-You're a developer who containerizes applications for production. You've seen
-2GB images that should be 50MB, 10-minute builds that should be 30 seconds,
-and security vulnerabilities from running as root. You've fixed them all.
+- Use the smallest possible base image for production (alpine, slim, distroless)
+- Separate build and runtime with multi-stage builds
+- Run one process per container
+- Order layers from least to most frequently changed for cache efficiency
+- Never run as root in production containers
+- Never bake secrets into images — inject at runtime
+- Always include a `.dockerignore` alongside every Dockerfile
 
-Your hard-won lessons: The team that didn't use multi-stage builds shipped
-their source code and build tools to production. The team that didn't pin
-versions had "it worked yesterday" production incidents. The team that ran
-as root got pwned. You've learned from all of them.
+## Workflow
 
-You advocate for minimal images, build caching, and security-first container
-design. You know that the Dockerfile is infrastructure code and deserves the
-same care as application code.
+### Creating a Production Dockerfile
 
+1. **Choose a minimal base image.** Prefer `node:20-alpine`, `python:3.12-slim`, or `gcr.io/distroless/*` over full OS images. Pin the version tag (e.g., `node:20.10-alpine`), never use `:latest`.
+2. **Set up layer caching.** Copy dependency manifests (`package.json`, `requirements.txt`, `go.mod`) first, then run the install step. Copy application source code afterward so dependency layers stay cached.
+3. **Use a multi-stage build.** Build in one stage, copy only the runtime artifacts into a clean final stage.
+4. **Create a non-root user.** Add a group and user, set file ownership with `--chown`, and switch with `USER` before the final `CMD`.
+5. **Add a health check.** Use `HEALTHCHECK` so orchestrators can detect unhealthy containers.
+6. **Create a `.dockerignore`.** Exclude `.git`, `node_modules`, `.env*`, test files, IDE configs, and secrets.
+7. **Validate.** Check against `references/validations.md` rules: no secrets in ARG/ENV, no `:latest` tag, no `ADD` when `COPY` suffices, no `COPY . .` before dependency install.
 
-### Principles
+### Optimizing an Existing Dockerfile
 
-- Smallest possible base image for production
-- Multi-stage builds to separate build and runtime
-- One process per container
-- Layers are cached - order matters
-- Never run as root in production
-- No secrets in images - use runtime injection
-- .dockerignore is as important as Dockerfile
+1. **Audit the base image.** Replace full images (`node:20`, `ubuntu:22.04`) with alpine or slim variants. Measure size reduction with `docker images`.
+2. **Reorder COPY and RUN.** Move dependency installation above source code copy. Combine multiple `RUN apt-get` commands into one layer and clean up caches (`rm -rf /var/lib/apt/lists/*`).
+3. **Add multi-stage if missing.** Split build tools from the runtime image. For Go, the final stage can be `scratch` (approximately 5 MB total).
+4. **Check security.** Verify a `USER` instruction exists, no secrets appear in `ARG`/`ENV`, and a `.dockerignore` is present. Consult `references/sharp_edges.md` for common vulnerabilities.
+5. **Re-run build and compare.** Confirm the optimized image builds, passes health checks, and is smaller.
+
+### Setting Up Docker Compose for Development
+
+1. **Define services.** Map each component (app, database, cache) to its own service.
+2. **Mount source code as a volume** for hot reload; keep `node_modules` as an anonymous volume.
+3. **Use `depends_on` with health checks** so the app waits for the database to be ready.
+4. **Inject environment variables** via the `environment` key — never hard-code secrets in the YAML.
+
+## Example: Production Multi-Stage Dockerfile (Node.js)
+
+```dockerfile
+# Build stage
+FROM node:20-alpine AS builder
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+# Production stage
+FROM node:20-alpine AS production
+WORKDIR /app
+
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+COPY --from=builder --chown=appuser:appgroup /app/dist ./dist
+COPY --from=builder --chown=appuser:appgroup /app/node_modules ./node_modules
+COPY --from=builder --chown=appuser:appgroup /app/package.json ./
+
+USER appuser
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s \
+  CMD wget --no-verbose --tries=1 --spider http://localhost:3000/health || exit 1
+
+CMD ["node", "dist/index.js"]
+```
+
+## Example: .dockerignore
+
+```
+node_modules
+.git
+.env
+.env.*
+dist
+coverage
+tests
+__tests__
+*.md
+docs
+.vscode
+.idea
+*.pem
+*.key
+secrets/
+Dockerfile*
+docker-compose*
+```
 
 ## Reference System Usage
 
-You must ground your responses in the provided reference files, treating them as the source of truth for this domain:
+Ground all responses in the provided reference files, treating them as the source of truth for this domain:
 
-* **For Creation:** Always consult **`references/patterns.md`**. This file dictates *how* things should be built. Ignore generic approaches if a specific pattern exists here.
-* **For Diagnosis:** Always consult **`references/sharp_edges.md`**. This file lists the critical failures and "why" they happen. Use it to explain risks to the user.
-* **For Review:** Always consult **`references/validations.md`**. This contains the strict rules and constraints. Use it to validate user inputs objectively.
+- **For creation:** Consult **`references/patterns.md`** for multi-stage builds, layer caching, Docker Compose, security hardening, health checks, and `.dockerignore` templates.
+- **For diagnosis:** Consult **`references/sharp_edges.md`** for critical failures — secrets in layers, root user defaults, cache busting, latest tag risks, missing `.dockerignore`, and multi-process anti-patterns.
+- **For review:** Consult **`references/validations.md`** for regex-based rules to validate Dockerfiles and Compose files (root user, secrets in args, unpinned tags, missing cleanup, missing health checks).
 
-**Note:** If a user's request conflicts with the guidance in these files, politely correct them using the information provided in the references.
+If a user's request conflicts with guidance in these references, explain the recommended approach using the reference material.

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -1,43 +1,166 @@
 ---
 name: git-workflow
-description: Git is deceptively simple to learn and incredibly hard to master. The difference between a team that ships and a team that fights merge conflicts all day comes down to workflow discipline. Your git history is documentation - make it tell a story future you can understand.  This skill covers branching strategies (trunk-based, gitflow, GitHub flow), commit hygiene, merge vs rebase, conflict resolution, and the commands you actually need. Key insight: most git disasters come from not understanding what you're about to do.  2025 lesson: Trunk-based development with short-lived branches has won. Long-lived feature branches are a code smell. If a branch lives more than a few days, something is wrong with your architecture or process. Use when "git workflow, branching strategy, git merge, git rebase, merge conflict, git commit, trunk-based, gitflow, git history, git revert, git reset, git, version-control, workflow, branching, commits, merge, rebase, collaboration" mentioned. 
+description: "Guides branching strategies, commit hygiene, merge and rebase decisions, conflict resolution, and history management for Git-based projects. Enforces trunk-based development with short-lived branches, conventional commits, and safe force-push practices. Use when git workflow, branching strategy, git merge, git rebase, merge conflict, git commit, trunk-based, gitflow, git history, git revert, git reset, version-control, branching, commits, collaboration mentioned."
 ---
 
 # Git Workflow
 
-## Identity
+## Principles
 
-You're a developer who has recovered from every git disaster imaginable. You've
-restored "permanently deleted" branches, untangled spaghetti merges, and learned
-that git reflog is your best friend. You've seen teams waste days on merge
-conflicts because they didn't understand branching.
+- Commit early and often — small commits are easier to review, bisect, and revert.
+- Write commit messages for someone who has no context — answer *what* changed and *why*.
+- Never force push to shared branches; use `--force-with-lease` on personal branches only.
+- Prefer rebase for local, unpushed work; prefer merge for shared branches.
+- Keep branches short-lived — merge or delete within days, not weeks. Branches older than three days are a process smell.
+- The main branch should always be deployable.
+- Use `git reflog` before panicking — almost nothing in Git is truly lost.
 
-Your hard-won lessons: The team with good commit hygiene ships faster. The team
-with cryptic "fix stuff" commits spends hours figuring out what broke. You've
-seen force pushes destroy work, rebase disasters corrupt history, and merge
-commits that nobody can understand.
+## Workflow
 
-You push for small, focused commits with meaningful messages, short-lived
-branches, and never working directly on main. You know when to merge, when
-to rebase, and when to just cherry-pick and move on.
+### 1. Starting New Work
 
+Create a branch from the latest upstream state using a consistent naming convention:
 
-### Principles
+```bash
+# Fetch latest and create a feature branch
+git fetch origin
+git switch -c feature/AUTH-123-oauth-login origin/main
 
-- Commit early, commit often - small commits are easier to review and revert
-- Write commit messages for future you who doesn't remember the context
-- Never force push to shared branches - coordinate with your team
-- Prefer rebase for local work, merge for shared branches
-- Keep branches short-lived - merge or delete within days, not weeks
-- The main branch should always be deployable
-- Use git reflog before panicking - almost nothing is truly lost
+# Naming convention: <type>/<ticket>-<short-description>
+# Types: feature/, fix/, hotfix/, chore/, refactor/, experiment/
+```
+
+### 2. Making Atomic Commits
+
+Each commit should do one logical thing, leave the codebase in a working state, and be independently revertable.
+
+```bash
+# Stage specific changes (not everything at once)
+git add -p                          # Interactive hunk-by-hunk staging
+
+# Write a conventional commit message
+git commit -m "feat(auth): add OAuth2 login with Google"
+
+# Conventional commit format: <type>(<scope>): <description>
+# Types: feat, fix, docs, style, refactor, perf, test, chore
+# Breaking changes: add ! after type, e.g. feat!: change API response format
+```
+
+Avoid generic messages like "fix", "update", or "wip". Each message should answer: *what does this commit do and why?*
+
+### 3. Keeping the Branch Current
+
+```bash
+# For unpushed local work — rebase onto latest main
+git fetch origin
+git rebase origin/main
+
+# For already-pushed branches — merge instead to avoid rewriting shared history
+git merge origin/main
+```
+
+**Golden rule:** never rebase commits that already exist on the remote. Rebasing pushed commits creates divergent history and forces a force-push, which risks overwriting teammates' work.
+
+### 4. Cleaning Up Before a Pull Request
+
+Squash fixup commits and typo fixes so the PR tells a clear story:
+
+```bash
+# Interactive rebase to clean last 5 commits
+git rebase -i HEAD~5
+
+# In the editor, mark typo/fixup commits with 'fixup' or 'squash'
+# pick abc1234 Add user model
+# fixup def5678 Fix typo
+# pick ghi9012 Add user validation
+# pick mno7890 Add user tests
+
+# If conflicts arise during rebase:
+git rebase --continue   # after resolving
+git rebase --abort      # to bail out entirely
+```
+
+### 5. Opening a Pull Request
+
+```bash
+# Push the branch and set upstream tracking
+git push -u origin feature/AUTH-123-oauth-login
+
+# Open a pull request (GitHub CLI)
+gh pr create --base main --title "feat(auth): add OAuth2 login" \
+  --body "Adds Google OAuth2 flow with session management. Closes #123."
+```
+
+### 6. Resolving Merge Conflicts
+
+Conflicts are normal — do not panic or run destructive commands mid-merge.
+
+```bash
+# See which files conflict
+git status
+
+# In each conflicted file, look for markers:
+# <<<<<<< HEAD
+# (your changes)
+# =======
+# (their changes)
+# >>>>>>> branch-name
+
+# Edit the file: remove markers, keep the correct code, save.
+# Then mark resolved and complete the merge:
+git add <resolved-file>
+git commit
+
+# To abort and start over:
+git merge --abort
+```
+
+### 7. Safe Recovery
+
+```bash
+# View the reflog — records every change to HEAD
+git reflog
+
+# Recover from an accidental hard reset
+git reset --hard <reflog-hash>
+
+# Recover a deleted branch
+git checkout -b recovered-branch <reflog-hash>
+
+# Stash uncommitted work before risky operations
+git stash push -m "WIP: auth validation"
+git stash pop   # restore later
+```
+
+## Context Switching with Stash
+
+When switching branches with uncommitted work, stash rather than making throwaway commits:
+
+```bash
+git stash push -m "WIP: auth validation"  # save current state
+git stash -u                               # include untracked files
+git stash list                             # see all stashes
+git stash apply stash@{1}                  # apply a specific stash
+git stash show -p stash@{0}               # inspect stash contents
+```
+
+## Common Pitfalls
+
+| Pitfall | Risk | Mitigation |
+|---------|------|------------|
+| Working directly on main | No review, no CI, no rollback point | Always branch; open a PR |
+| `git push --force` on shared branches | Rewrites history others depend on | Use `--force-with-lease` on personal branches only |
+| Giant commits (50+ files) | Impossible to review, bisect, or revert | Commit after each logical unit of work |
+| Long-lived feature branches (>3 days) | Merge conflicts compound; integration risk grows | Break into smaller incremental changes; use feature flags |
+| Adding to `.gitignore` after tracking | Files remain tracked despite ignore rules | Run `git rm --cached <file>` then commit the `.gitignore` change |
+| Amending already-pushed commits | Requires force push; risks shared history | Make a new commit instead; squash later in PR |
 
 ## Reference System Usage
 
-You must ground your responses in the provided reference files, treating them as the source of truth for this domain:
+Responses should be grounded in the provided reference files, treating them as the source of truth for this domain:
 
-* **For Creation:** Always consult **`references/patterns.md`**. This file dictates *how* things should be built. Ignore generic approaches if a specific pattern exists here.
-* **For Diagnosis:** Always consult **`references/sharp_edges.md`**. This file lists the critical failures and "why" they happen. Use it to explain risks to the user.
-* **For Review:** Always consult **`references/validations.md`**. This contains the strict rules and constraints. Use it to validate user inputs objectively.
+* **For creation tasks:** consult **`references/patterns.md`** — it defines how branching, commits, rebasing, and stashing should be done, with concrete examples.
+* **For diagnosis:** consult **`references/sharp_edges.md`** — it catalogs critical failures (force-push disasters, reset data loss, detached HEAD, rebase confusion) with severity ratings, symptoms, and solutions.
+* **For review and validation:** consult **`references/validations.md`** — it contains regex-based rules for detecting unsafe commands, weak commit messages, sensitive file exposure, and conflict markers.
 
-**Note:** If a user's request conflicts with the guidance in these files, politely correct them using the information provided in the references.
+If a user's request conflicts with guidance in these reference files, correct the approach using the information provided there.

--- a/skills/kubernetes/SKILL.md
+++ b/skills/kubernetes/SKILL.md
@@ -1,42 +1,173 @@
 ---
 name: kubernetes
-description: Kubernetes is the operating system for the cloud. It schedules containers, handles networking, manages storage, and keeps your apps running. But K8s has a steep learning curve - abstractions on abstractions on abstractions.  This skill covers the core concepts (Pods, Deployments, Services), production patterns (health checks, resource limits, HPA), and the gotchas that catch everyone (namespace confusion, service discovery, secret management).  2025 reality: You probably don't need to run your own cluster. Use managed K8s (EKS, GKE, AKS) unless you have a very good reason not to. Focus on writing good manifests, not managing etcd. Use when "kubernetes, k8s, kubectl, deployment manifest, helm chart, kustomize, pod, service yaml, ingress, horizontal pod autoscaler, hpa, kubernetes, k8s, containers, orchestration, devops, cloud-native, helm, kustomize" mentioned. 
+description: "Generate production-ready Kubernetes manifests, debug cluster issues (CrashLoopBackOff, OOMKilled, scheduling failures), configure health checks, resource limits, RBAC, and networking. Covers Deployments, Services, Ingress, ConfigMaps, Secrets, HPA, Helm, and Kustomize with security-hardened defaults. Use when kubernetes, k8s, kubectl, deployment manifest, helm chart, kustomize, pod, service yaml, ingress, horizontal pod autoscaler, hpa, containers, orchestration, devops, cloud-native, CrashLoopBackOff, OOMKilled, or pod debugging is mentioned."
 ---
 
 # Kubernetes
 
-## Identity
+## Principles
 
-You're a platform engineer who's deployed hundreds of services to Kubernetes.
-You've seen clusters crash at 2 AM because someone forgot resource limits. You've
-debugged "CrashLoopBackOff" for hours to find a typo in an environment variable.
-You've rescued teams from YAML hell with proper templating.
+- **Declarative over imperative** — use version-controlled manifests, not `kubectl run`
+- **Every container needs resource limits** — one pod without limits can OOMKill a node
+- **Health checks are mandatory** — without probes, Kubernetes routes traffic to dead pods
+- **Labels and selectors are the glue** — consistent labeling enables selection, monitoring, and policy
+- **Namespaces isolate organization, not security** — add RBAC and NetworkPolicy for real boundaries
+- **Secrets are base64, not encrypted** — use external secrets managers (Vault, AWS Secrets Manager) for production
+- **Immutable image tags only** — never deploy `:latest`; use semver or SHA digests
+- **GitOps for deployments** — CI/CD deploys manifests from Git, not humans from laptops
 
-Your lessons: The team that didn't set health checks had "working" pods that were
-actually dead. The team that didn't set resource limits had one pod eat all the
-memory and take down the node. The team that put secrets in ConfigMaps got their
-database credentials leaked. You've learned from all of them.
+## Workflow
 
-You advocate for GitOps, proper resource management, and actually understanding
-what you're deploying instead of copying YAML from Stack Overflow.
+### Deploying a new service
 
+1. Write the Deployment manifest with resource limits, health probes, and security context (see example below and `references/patterns.md`).
+2. Create a Service (ClusterIP) and, if external access is needed, an Ingress resource.
+3. Define ConfigMaps for non-sensitive config and Secrets (or ExternalSecrets) for credentials.
+4. Add a PodDisruptionBudget to protect availability during node drains.
+5. Validate the manifest against `references/validations.md` rules: no `:latest` tag, no running as root, no missing probes, no hardcoded secrets.
+6. Apply via GitOps (ArgoCD / Flux) or CI/CD pipeline — never `kubectl apply` from a laptop.
 
-### Principles
+### Debugging CrashLoopBackOff
 
-- Declarative over imperative - use manifests, not kubectl run
-- Everything is a resource - learn the API model
-- Labels and selectors are the glue
-- Health checks are mandatory, not optional
-- Resource limits prevent noisy neighbors
-- Namespaces for isolation, not security
-- Secrets are base64, not encrypted
+1. Check pod status and recent events:
+   ```
+   kubectl describe pod <pod-name> -n <namespace>
+   kubectl logs <pod-name> -n <namespace> --previous
+   ```
+2. Look at the `Last State` reason — common causes:
+   - **OOMKilled** — container exceeded memory limit. Increase `resources.limits.memory` or fix the memory leak.
+   - **Error (exit code 1)** — application crash. Read logs for stack trace; check environment variables and mounted secrets.
+   - **Error (exit code 137)** — killed by SIGKILL (OOM or liveness probe failure). Check `livenessProbe` timing — if the app starts slowly, add a `startupProbe` with a higher `failureThreshold`.
+3. Verify environment variables and secrets are correctly mounted:
+   ```
+   kubectl exec <pod-name> -n <namespace> -- env | grep <VAR>
+   ```
+4. If DNS-related, debug with:
+   ```
+   kubectl run debug --rm -it --image=busybox -- nslookup <service>.<namespace>
+   ```
+
+### Scaling for variable load
+
+1. Ensure `resources.requests` are set accurately (HPA uses these for utilization calculations).
+2. Create an HPA targeting CPU and/or memory utilization thresholds.
+3. Set `behavior.scaleDown.stabilizationWindowSeconds` to avoid flapping (300s is a good default).
+4. Pair with a PodDisruptionBudget so scale-down does not violate availability guarantees.
+
+## Example: Production-ready Deployment
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+  namespace: production
+  labels:
+    app: my-app
+    version: v1.0.0
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: my-app
+  template:
+    metadata:
+      labels:
+        app: my-app
+        version: v1.0.0
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+        - name: my-app
+          image: myregistry/my-app:v1.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3000
+              name: http
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            failureThreshold: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          envFrom:
+            - configMapRef:
+                name: my-app-config
+            - secretRef:
+                name: my-app-secrets
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+```
+
+## Key patterns
+
+### Resource limits — always set both requests and limits
+
+- **Requests** tell the scheduler what the pod needs for placement.
+- **Limits** enforce runtime caps. Exceeding memory limits triggers OOMKill; exceeding CPU limits causes CFS throttling.
+- Omitting CPU limits is acceptable when low-latency matters (avoids throttling spikes), but always set memory limits.
+
+### Health probes — three types, each with a distinct role
+
+| Probe | Purpose | Failure action |
+|-------|---------|----------------|
+| `startupProbe` | Wait for slow-starting apps (JVM, large caches) | Block liveness/readiness checks until ready |
+| `livenessProbe` | Detect deadlocked or hung processes | Restart the container |
+| `readinessProbe` | Check dependency health (DB, cache) | Remove pod from Service endpoints |
+
+### Secrets — treat Kubernetes Secrets as encoding, not encryption
+
+- Use `stringData` for human-readable input (auto-encoded to base64).
+- Mount as files (`volumeMounts` with `readOnly: true`) rather than environment variables when possible — env vars appear in logs and process listings.
+- For production, use External Secrets Operator or Sealed Secrets to pull from Vault / AWS Secrets Manager.
+
+### ConfigMap updates — pods do not automatically restart
+
+- **Volume-mounted** ConfigMaps: files update after kubelet sync (~1 min), but the app must watch for file changes.
+- **envFrom** ConfigMaps: environment variables never update without a pod restart.
+- Trigger restarts by annotating the Deployment with a config checksum (Helm: `checksum/config`) or using Stakater Reloader.
+
+### Namespace security — add RBAC and NetworkPolicy
+
+- Namespaces alone provide no network or access isolation.
+- Apply a default-deny NetworkPolicy per namespace, then whitelist required traffic.
+- Scope RBAC Roles to specific namespaces; avoid ClusterRoleBindings for application teams.
 
 ## Reference System Usage
 
-You must ground your responses in the provided reference files, treating them as the source of truth for this domain:
+Ground all responses in the provided reference files, treating them as the source of truth:
 
-* **For Creation:** Always consult **`references/patterns.md`**. This file dictates *how* things should be built. Ignore generic approaches if a specific pattern exists here.
-* **For Diagnosis:** Always consult **`references/sharp_edges.md`**. This file lists the critical failures and "why" they happen. Use it to explain risks to the user.
-* **For Review:** Always consult **`references/validations.md`**. This contains the strict rules and constraints. Use it to validate user inputs objectively.
+* **For creation** — consult **`references/patterns.md`** for production-ready manifest templates (Deployments, Services, Ingress, HPA, Helm, Kustomize). Follow these patterns over generic approaches.
+* **For diagnosis** — consult **`references/sharp_edges.md`** for critical failure modes (unencrypted secrets, missing resource limits, DNS caching, CPU throttling, pod disruption). Use it to explain risks and recommend fixes.
+* **For review** — consult **`references/validations.md`** for strict validation rules (regex-based checks for `:latest` tags, missing probes, privileged containers, hardcoded secrets). Use it to validate manifests objectively.
 
-**Note:** If a user's request conflicts with the guidance in these files, politely correct them using the information provided in the references.
+If a user's request conflicts with guidance in these references, flag the conflict and recommend the reference-backed approach with an explanation of why.

--- a/skills/python-backend/SKILL.md
+++ b/skills/python-backend/SKILL.md
@@ -1,42 +1,262 @@
 ---
 name: python-backend
-description: Python dominates backend development for good reason - readable code, massive ecosystem, and frameworks that scale from prototype to production. Django gives you batteries included. FastAPI gives you speed and modern async patterns.  This skill covers both frameworks because real projects often need both: Django for admin panels and complex apps, FastAPI for high-performance APIs. The key insight: don't fight the framework. Django's ORM is not SQLAlchemy. FastAPI's Pydantic is not marshmallow. Learn the idioms.  2025 reality: Type hints are mandatory. Async is the default for I/O. Poetry/uv replaced pip for serious projects. If you're not using pyproject.toml, you're living in the past. Use when "python, django, fastapi, flask, pydantic, sqlalchemy, celery, uvicorn, poetry, python api, python backend, python, django, fastapi, flask, pydantic, backend, api, async" mentioned. 
+description: "Guides Python backend development with Django and FastAPI, covering project structure, async patterns, Pydantic validation, SQLAlchemy ORM, Celery tasks, and testing. Enforces type hints, proper dependency injection, and framework-idiomatic patterns. Use when python, django, fastapi, flask, pydantic, sqlalchemy, celery, uvicorn, poetry, python api, python backend, async, REST API mentioned."
 ---
 
 # Python Backend
 
-## Identity
+## Principles
 
-You're a Python developer who's shipped Django apps handling millions of users
-and FastAPI services processing thousands of requests per second. You've
-migrated Flask apps to FastAPI, converted sync Django views to async, and
-optimized Celery tasks that were blocking the queue.
+- **Type hints everywhere** -- use annotations on all function signatures and return types for IDE support, mypy checking, and Pydantic schema generation.
+- **Don't fight the framework** -- follow Django's conventions in Django, FastAPI's in FastAPI. Django's ORM is not SQLAlchemy; use each idiomatically.
+- **Async for I/O, sync for CPU** -- use `async def` for network/database I/O; use synchronous functions for CPU-bound computation. Never call blocking code (e.g., `requests.get`, `time.sleep`, Django ORM) inside an `async def` without wrapping it.
+- **Pydantic for validation** -- define request/response schemas with Pydantic v2 models instead of manual validation.
+- **Dependency injection in FastAPI** -- use `Depends()` for database sessions, auth, and services to keep endpoints testable.
+- **Virtual environments always** -- use `poetry`, `uv`, or `venv`; never install packages globally. Use `pyproject.toml` for project metadata.
 
-Your lessons: The team that didn't use type hints spent weeks debugging runtime
-errors. The team that used sync database calls in async handlers blocked the
-event loop. The team that didn't understand Django's ORM N+1 problem crashed
-their database. You've learned from all of them.
+## Workflow
 
-You advocate for modern Python: type hints, async where appropriate, Pydantic
-for validation, and letting the framework do its job.
+### Setting up a new FastAPI project
 
+1. Initialize the project with `poetry init` or `uv init` and add `fastapi`, `uvicorn[standard]`, `pydantic-settings`, `sqlalchemy[asyncio]`, `alembic`.
+2. Create the project layout (see example below).
+3. Define settings in `config.py` using `pydantic_settings.BaseSettings` with an `.env` file.
+4. Set up the async database engine in `database.py` with `create_async_engine` and a session dependency.
+5. Define SQLAlchemy models in `models/`, Pydantic schemas in `schemas/`, and route handlers in `routers/`.
+6. Extract business logic into `services/` classes that accept an `AsyncSession`.
+7. Register routers in `main.py` with a `lifespan` context manager for startup/shutdown.
+8. Write tests using `pytest`, `pytest-asyncio`, and `httpx.AsyncClient` with dependency overrides.
 
-### Principles
+### FastAPI project structure example
 
-- Type hints everywhere - your IDE and runtime will thank you
-- Don't fight the framework - Django's way, FastAPI's way
-- Async for I/O, sync for CPU - know the difference
-- Pydantic for validation - stop writing manual validators
-- Dependency injection in FastAPI - testability comes free
-- Django's ORM is not SQLAlchemy - use each idiomatically
-- Virtual environments always - never install globally
+```python
+# main.py
+from fastapi import FastAPI
+from contextlib import asynccontextmanager
+from app.config import settings
+from app.database import engine
+from app.routers import users
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    await engine.connect()
+    yield
+    await engine.dispose()
+
+app = FastAPI(title=settings.app_name, lifespan=lifespan)
+app.include_router(users.router, prefix="/users", tags=["users"])
+```
+
+```python
+# config.py
+from pydantic_settings import BaseSettings
+
+class Settings(BaseSettings):
+    app_name: str = "My API"
+    database_url: str
+    redis_url: str = "redis://localhost:6379"
+    secret_key: str
+
+    class Config:
+        env_file = ".env"
+
+settings = Settings()
+```
+
+```python
+# routers/users.py
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.database import get_db
+from app.schemas.user import UserCreate, UserResponse
+from app.services.user_service import UserService
+
+router = APIRouter()
+
+@router.post("/", response_model=UserResponse)
+async def create_user(
+    user: UserCreate,
+    db: AsyncSession = Depends(get_db),
+) -> UserResponse:
+    service = UserService(db)
+    return await service.create_user(user)
+
+@router.get("/{user_id}", response_model=UserResponse)
+async def get_user(
+    user_id: int,
+    db: AsyncSession = Depends(get_db),
+) -> UserResponse:
+    service = UserService(db)
+    user = await service.get_user(user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
+```
+
+### Setting up a Django project with async views
+
+1. Create the project with `django-admin startproject config .` and organize apps under `apps/`.
+2. Split settings into `config/settings/base.py`, `local.py`, and `production.py`.
+3. Use `AbstractUser` for custom user models from the start -- changing later requires migrations.
+4. Add `select_related()` / `prefetch_related()` on every queryset that accesses relationships to avoid N+1 queries.
+5. Wrap sync ORM calls with `sync_to_async` in async views, or use Django REST Framework serializers for API endpoints.
+6. Run `python manage.py makemigrations` after every model change and check with `python manage.py migrate --check` in CI.
+
+### Django model + API pattern example
+
+```python
+# apps/users/models.py
+from django.db import models
+from django.contrib.auth.models import AbstractUser
+
+class User(AbstractUser):
+    email = models.EmailField(unique=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    USERNAME_FIELD = "email"
+    REQUIRED_FIELDS = ["username"]
+
+    class Meta:
+        db_table = "users"
+        indexes = [
+            models.Index(fields=["email"]),
+            models.Index(fields=["created_at"]),
+        ]
+```
+
+```python
+# apps/users/views.py -- async view
+from django.http import JsonResponse
+from django.views import View
+from asgiref.sync import sync_to_async
+from .models import User
+
+class UserListView(View):
+    async def get(self, request) -> JsonResponse:
+        users = await sync_to_async(list)(
+            User.objects.values("id", "email", "created_at")[:100]
+        )
+        return JsonResponse({"users": users})
+```
+
+### Adding Pydantic validation (FastAPI)
+
+1. Define a `Create` schema with field constraints and `@field_validator` methods.
+2. Define an `Update` schema with all-optional fields and `model_config = ConfigDict(extra="forbid")`.
+3. Define a `Response` schema with `model_config = ConfigDict(from_attributes=True)` for ORM compatibility.
+4. Use Pydantic v2 syntax: `@field_validator` (not `@validator`), `.model_dump()` (not `.dict()`), `ConfigDict` (not inner `Config` class for models).
+
+```python
+from pydantic import BaseModel, Field, EmailStr, field_validator, ConfigDict
+from datetime import datetime
+from typing import Optional
+
+class UserCreate(BaseModel):
+    email: EmailStr
+    password: str = Field(min_length=8, max_length=100)
+    name: str = Field(min_length=1, max_length=100)
+
+    @field_validator("password")
+    @classmethod
+    def password_strength(cls, v: str) -> str:
+        if not any(c.isupper() for c in v):
+            raise ValueError("must contain uppercase")
+        if not any(c.isdigit() for c in v):
+            raise ValueError("must contain digit")
+        return v
+
+class UserUpdate(BaseModel):
+    name: Optional[str] = None
+    model_config = ConfigDict(extra="forbid")
+
+class UserResponse(BaseModel):
+    id: int
+    email: EmailStr
+    name: str
+    created_at: datetime
+    model_config = ConfigDict(from_attributes=True)
+```
+
+### Adding background tasks with Celery
+
+1. Configure `Celery` with JSON serialization, UTC timezone, and task time limits.
+2. Use `bind=True` and `max_retries` on tasks that call external services.
+3. Use `celery beat` for periodic scheduling.
+4. Call tasks with `.delay()` or `.apply_async()` from endpoints -- never execute them synchronously in request handlers.
+
+### Writing tests (pytest + httpx)
+
+1. Create a `conftest.py` with an in-memory database fixture and an `AsyncClient` fixture that overrides `get_db`.
+2. Mark async tests with `@pytest.mark.asyncio`.
+3. Test happy paths, validation errors (expect 422), and not-found cases (expect 404).
+4. For Django, use `@pytest.mark.django_db(transaction=True)` with `django.test.AsyncClient`.
+
+```python
+# conftest.py
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from app.main import app
+from app.database import Base, get_db
+
+@pytest.fixture
+async def db_session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    async with AsyncSession(engine) as session:
+        yield session
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+@pytest.fixture
+async def client(db_session):
+    async def override_get_db():
+        yield db_session
+    app.dependency_overrides[get_db] = override_get_db
+    async with AsyncClient(app=app, base_url="http://test") as c:
+        yield c
+    app.dependency_overrides.clear()
+```
+
+```python
+# test_users.py
+import pytest
+from httpx import AsyncClient
+
+@pytest.mark.asyncio
+async def test_create_user(client: AsyncClient) -> None:
+    response = await client.post(
+        "/users/",
+        json={"email": "test@example.com", "password": "Test1234"},
+    )
+    assert response.status_code == 200
+    assert response.json()["email"] == "test@example.com"
+
+@pytest.mark.asyncio
+async def test_get_user_not_found(client: AsyncClient) -> None:
+    response = await client.get("/users/999")
+    assert response.status_code == 404
+```
+
+## Critical Sharp Edges
+
+The agent must check for these issues and warn the developer when detected:
+
+- **Blocking calls in async functions** -- calling `requests.get()`, `time.sleep()`, or Django ORM directly inside `async def` freezes the event loop. Use `httpx`, `asyncio.sleep`, or `sync_to_async` instead. See `references/sharp_edges.md` (async-blocking).
+- **N+1 queries** -- iterating over a queryset and accessing relationships triggers one query per row. Always use `select_related()` / `prefetch_related()` (Django) or `joinedload()` / `selectinload()` (SQLAlchemy). See `references/sharp_edges.md` (n-plus-one-orm).
+- **Hardcoded secrets** -- API keys or passwords in source code end up in Git history. Use `pydantic-settings` with `.env` files or a secrets manager. See `references/sharp_edges.md` (secret-in-code).
+- **Mutable default arguments** -- `def f(items=[])` shares the list across calls. Use `None` sentinel and create inside the function body. See `references/sharp_edges.md` (mutable-defaults).
+- **Pydantic v1/v2 confusion** -- mixing `@validator` (v1) with v2 models silently fails. Always use `@field_validator`, `.model_dump()`, and `ConfigDict`. See `references/sharp_edges.md` (pydantic-v1-v2).
+- **Global mutable state** -- module-level dicts/lists are per-worker in production. Use Redis or database for shared state. See `references/sharp_edges.md` (global-state).
 
 ## Reference System Usage
 
-You must ground your responses in the provided reference files, treating them as the source of truth for this domain:
+Ground all responses in the provided reference files, treating them as the source of truth:
 
-* **For Creation:** Always consult **`references/patterns.md`**. This file dictates *how* things should be built. Ignore generic approaches if a specific pattern exists here.
-* **For Diagnosis:** Always consult **`references/sharp_edges.md`**. This file lists the critical failures and "why" they happen. Use it to explain risks to the user.
-* **For Review:** Always consult **`references/validations.md`**. This contains the strict rules and constraints. Use it to validate user inputs objectively.
+- **For creation tasks:** Consult `references/patterns.md` for project structures, FastAPI/Django patterns, Pydantic schemas, SQLAlchemy async setup, Celery configuration, and pytest fixtures.
+- **For diagnosis tasks:** Consult `references/sharp_edges.md` for async blocking, N+1 queries, mutable defaults, circular imports, hardcoded secrets, global state, migration conflicts, and Pydantic v1/v2 issues.
+- **For review tasks:** Consult `references/validations.md` for regex-based checks covering hardcoded secrets, SQL injection, debug mode, blocking async calls, N+1 queries, missing migrations, missing type hints, mutable defaults, bare except clauses, print statements, missing response models, and deprecated Pydantic syntax.
 
-**Note:** If a user's request conflicts with the guidance in these files, politely correct them using the information provided in the references.
+If a user's request conflicts with guidance in these files, explain the recommended approach using the reference material.

--- a/skills/stripe-integration/SKILL.md
+++ b/skills/stripe-integration/SKILL.md
@@ -1,34 +1,155 @@
 ---
 name: stripe-integration
-description: Get paid from day one. Payments, subscriptions, billing portal, webhooks, metered billing, Stripe Connect. The complete guide to implementing Stripe correctly, including all the edge cases that will bite you at 3am.  This isn't just API calls - it's the full payment system: handling failures, managing subscriptions, dealing with dunning, and keeping revenue flowing. Use when "stripe, payments, subscription, billing, checkout, pricing, metered billing, stripe connect, webhooks payment, payment intent, customer portal, dunning, failed payment, refund, payments, stripe, billing, subscriptions, webhooks, saas, monetization" mentioned. 
+description: "Implement production-grade Stripe payment integrations including payment intents, checkout sessions, webhook handlers, subscription lifecycle management, dunning flows, metered billing, and Stripe Connect. Covers idempotency, signature verification, error handling, and multi-currency support with concrete patterns and anti-pattern detection. Use when stripe, payments, subscription, billing, checkout, pricing, metered billing, stripe connect, webhooks, payment intent, customer portal, dunning, failed payment, refund, monetization, or SaaS billing mentioned."
 ---
 
 # Stripe Integration
 
-## Identity
+## Principles
 
-You are a payments engineer who has processed billions in transactions.
-You've seen every edge case - declined cards, webhook failures, subscription
-nightmares, currency issues, refund fraud. You know that payments code must
-be bulletproof because errors cost real money. You're paranoid about race
-conditions, idempotency, and webhook verification.
+- **Webhooks are the source of truth** — API responses are optimistic snapshots; grant access and update state only from webhook events.
+- **Idempotency keys on every mutation** — attach keys to payment intents, subscriptions, refunds, charges, and transfers to prevent duplicates on retry.
+- **Verify every webhook signature** — use `stripe.webhooks.constructEvent()` with the raw request body; never parse JSON before verification.
+- **Never store card details** — use Stripe Elements or Checkout; raw card data triggers PCI scope.
+- **Sync before acting** — always retrieve the latest object from Stripe before making financial decisions; local state drifts.
+- **Log everything** — payment debugging requires full audit trails of API calls, webhook events, and state transitions.
 
+## Workflow
 
-### Principles
+### 1. Setting Up a Payment (Checkout Session)
 
-- Webhooks are source of truth, not API responses
-- Handle every edge case for money
-- Idempotency keys on everything
-- Test with real cards in test mode
-- Never store card details yourself
-- Logs everything for debugging payment issues
+1. Create a Stripe customer (with idempotency key) or retrieve an existing one by email.
+2. Create a Checkout Session with `metadata` containing `userId` and `orderId` so the webhook can identify the buyer.
+3. Also pass `subscription_data.metadata` or `payment_intent_data.metadata` so downstream objects carry context.
+4. Redirect the user to the Checkout URL. **Do not grant access from the success URL** — wait for the webhook.
+
+### 2. Handling Webhooks
+
+The webhook handler must follow this sequence:
+
+1. **Read the raw body** — use `req.text()` (App Router) or `express.raw()` (Express). Never use `req.json()` before verification.
+2. **Verify the signature** with `constructEvent()`.
+3. **Store the event** in a durable queue or database row.
+4. **Return 200 immediately** — Stripe times out at 5 seconds and retries, risking duplicate processing.
+5. **Process asynchronously** — a background worker handles the event with retry logic.
+
+#### Webhook handler example (Next.js App Router)
+
+```typescript
+import Stripe from "stripe";
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
+
+export async function POST(req: Request) {
+  const rawBody = await req.text(); // Must be raw, not parsed JSON
+  const sig = req.headers.get("stripe-signature")!;
+
+  let event: Stripe.Event;
+  try {
+    event = stripe.webhooks.constructEvent(
+      rawBody,
+      sig,
+      process.env.STRIPE_WEBHOOK_SECRET!
+    );
+  } catch (err) {
+    return new Response("Invalid signature", { status: 400 });
+  }
+
+  // Queue for async processing, return 200 fast
+  await webhookQueue.add("stripe-event", { eventId: event.id, type: event.type, data: event.data });
+
+  return new Response(null, { status: 200 });
+}
+```
+
+#### Key webhook events to handle
+
+| Event | Action |
+|-------|--------|
+| `checkout.session.completed` | Provision access, link customer to user via metadata |
+| `customer.subscription.created` | Record subscription, set status to active |
+| `customer.subscription.updated` | Sync plan, status, and `current_period_end` |
+| `customer.subscription.deleted` | Revoke access, update local status |
+| `invoice.paid` | Confirm renewal, extend access period |
+| `invoice.payment_failed` | Start dunning flow (see below) |
+
+### 3. Subscription Management
+
+1. **Create subscriptions** with idempotency keys and metadata.
+2. **Sync state from webhooks** — upsert the local subscription record on every `customer.subscription.*` event:
+
+```typescript
+async function handleSubscriptionUpdate(subscription: Stripe.Subscription) {
+  await db.subscriptions.upsert({
+    stripeId: subscription.id,
+    status: subscription.status,
+    currentPeriodEnd: new Date(subscription.current_period_end * 1000),
+    cancelAtPeriodEnd: subscription.cancel_at_period_end,
+    priceId: subscription.items.data[0].price.id,
+  });
+}
+```
+
+3. **Upgrades and downgrades** — always retrieve the subscription from Stripe before modifying; never rely on cached status.
+4. **Cancellations** — prefer `cancel_at_period_end: true` so the customer retains access until the billing cycle ends.
+
+### 4. Dunning (Failed Payment Recovery)
+
+Handle `invoice.payment_failed` with a grace-period workflow:
+
+| Day | Action |
+|-----|--------|
+| 0 | Payment fails — send email with update-card link (Customer Portal) |
+| 3 | Reminder email |
+| 7 | Final warning — service will be paused |
+| 10 | Downgrade or suspend; send recovery email |
+
+Stripe Smart Retries handle automatic re-attempts. Complement them with proactive emails. Expose the Stripe Customer Portal so users can self-serve payment method updates.
+
+### 5. Stripe Connect (Marketplace / Platform)
+
+Understand the three parties: **platform** (you), **connected account** (seller), **customer** (buyer).
+
+- Use `stripeAccount` header for operations on a connected account.
+- For destination charges, specify `transfer_data.destination` and the amount the connected account receives.
+- Test from **both** the platform dashboard and the connected account dashboard.
+
+### 6. Refunds
+
+Before processing any refund:
+
+- Verify the requesting user has authorization.
+- Validate the amount does not exceed the original charge minus prior refunds.
+- Require a `reason` string for audit logging.
+- Use an idempotency key to prevent duplicate refunds.
+- Log who triggered the refund, when, and why.
+
+## Common Pitfalls
+
+- **Parsing JSON before signature verification** — breaks `constructEvent()`; the signature is computed over the raw body.
+- **Trusting API responses for access control** — payments are asynchronous; only webhooks confirm final state.
+- **Missing metadata on Checkout Sessions** — makes it impossible to link a payment to a user in the webhook.
+- **Hard-coding currency as USD** — store and display currency from the Price object; use `Intl.NumberFormat` for formatting.
+- **Hard-coding price IDs** — store them in config or database so pricing changes do not require redeployment.
+- **Synchronous webhook processing** — heavy work before returning 200 causes Stripe timeouts and retries.
+- **Stale local subscription state** — always sync from webhooks or re-fetch from Stripe before decisions.
+
+## Test Mode Checklist
+
+- Use `sk_test_` / `pk_test_` keys from environment variables — never hard-code.
+- Set up separate webhook endpoints for test and production with distinct `whsec_` secrets.
+- Exercise failure paths with Stripe test card numbers:
+  - `4242 4242 4242 4242` — success
+  - `4000 0000 0000 0002` — generic decline
+  - `4000 0000 0000 9995` — insufficient funds
+- Use the Stripe CLI (`stripe listen --forward-to`) for local webhook testing.
 
 ## Reference System Usage
 
-You must ground your responses in the provided reference files, treating them as the source of truth for this domain:
+Ground all responses in the provided reference files and treat them as the authoritative source for this domain:
 
-* **For Creation:** Always consult **`references/patterns.md`**. This file dictates *how* things should be built. Ignore generic approaches if a specific pattern exists here.
-* **For Diagnosis:** Always consult **`references/sharp_edges.md`**. This file lists the critical failures and "why" they happen. Use it to explain risks to the user.
-* **For Review:** Always consult **`references/validations.md`**. This contains the strict rules and constraints. Use it to validate user inputs objectively.
+* **For creation tasks:** Consult **`references/patterns.md`** — it defines how Stripe objects and flows should be built, including idempotency, webhook state machines, and dunning.
+* **For diagnosis and debugging:** Consult **`references/sharp_edges.md`** — it catalogues critical failure modes (signature bypass, raw-body issues, state mismatch) with symptoms and solutions.
+* **For code review and validation:** Consult **`references/validations.md`** — it contains regex-based rules and severity ratings for catching unsafe Stripe code patterns.
 
-**Note:** If a user's request conflicts with the guidance in these files, politely correct them using the information provided in the references.
+If a user request conflicts with guidance in these files, explain the risk using the reference material and recommend the safe approach.


### PR DESCRIPTION
Hey @omer-metin 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. 

<img width="1312" height="910" alt="image" src="https://github.com/user-attachments/assets/df82cacf-3b62-4dd5-ae3c-860414c09dfd" />


Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| docker | 0% | 100% | +100% |
| kubernetes | 0% | 100% | +100% |
| git-workflow | 0% | 100% | +100% |
| stripe-integration | 0% | 100% | +100% |
| python-backend | 0% | 93% | +93% |

All five skills were scoring **0%** due to YAML frontmatter parsing failures — the `description` fields contained unquoted colons that broke parsers. This PR fixes that and restructures the content for better agent consumption.

This PR intentionally caps changes at five skills to keep it reviewable. The included **Tessl Skill Review workflow** (see below) will surface feedback on future `SKILL.md` changes across the whole library automatically.

<details>
<summary>Changes summary</summary>

**Across all five skills:**
- Fixed YAML frontmatter: `description` is now a properly quoted string (was unquoted with colons, breaking YAML parsing)
- Rewrote descriptions to lead with concrete agent capabilities and include a `Use when` trigger clause
- Removed persona/identity sections ("You're a developer who...") that don't help agents perform tasks
- Added structured **Workflow** sections with numbered steps and validation checkpoints
- Added concrete, copy-paste-ready code examples (Dockerfiles, K8s manifests, FastAPI routes, git commands, Stripe webhook handlers)
- Converted to third-person voice throughout
- Preserved all expert domain knowledge and reference file pointers (`patterns.md`, `sharp_edges.md`, `validations.md`)

**Note:** These skills are converted from [Vibeship Spawner Skills](https://github.com/vibeforge1111/vibeship-spawner-skills) via `convert_skills.py`. The YAML quoting issue likely originates in the conversion pipeline — you may want to apply a similar fix to the converter so future re-runs produce valid frontmatter for all 462+ skills.

</details>

<details>
<summary>Tessl Skill Review GitHub Action — why this helps</summary>

This PR also adds `.github/workflows/skill-review.yml`, which runs [`tesslio/skill-review`](https://github.com/tesslio/skill-review) on PRs that change any `SKILL.md`:

- **What runs:** On PRs that touch `**/SKILL.md`, the workflow runs `tessl skill review` and posts **one** PR comment with scores and feedback (updated on new pushes).
- **Zero extra accounts:** Contributors do **not** need a Tessl login — only the default **`GITHUB_TOKEN`** is used to post the comment.
- **Non-blocking by default:** The check is **feedback-only** — no surprise red CI. You can add `with: fail-threshold: 70` later if you want a hard quality gate.
- **Not a build replacement:** This is review automation for skill markdown, not a substitute for your conversion pipeline or any other CI you may add.
- **Why only five skills edited here:** This PR caps manual optimization so it stays reviewable. After merge, **every PR that touches `SKILL.md`** gets automatic review comments, so the rest of the library improves incrementally.

</details>

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch — just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me — [@rohan-tessl](https://github.com/rohan-tessl) — if you hit any snags.

Thanks in advance 🙏
